### PR TITLE
updated _startTime & _cpuTotal comments in Prometheus.NetStandard/Advanced/DotNetStatsCollector.cs

### DIFF
--- a/Prometheus.NetStandard/Advanced/DotNetStatsCollector.cs
+++ b/Prometheus.NetStandard/Advanced/DotNetStatsCollector.cs
@@ -39,8 +39,8 @@ namespace Prometheus.Advanced
             }
 
             // Metrics that make sense to compare between all operating systems
-            _startTime = metrics.CreateGauge("process_start_time_seconds", "Start time of the process since unix epoch in seconds");
-            _cpuTotal = metrics.CreateCounter("process_cpu_seconds_total", "Total user and system CPU time spent in seconds");
+            _startTime = metrics.CreateGauge("process_start_time_seconds", "Start time of the process since unix epoch in seconds.");
+            _cpuTotal = metrics.CreateCounter("process_cpu_seconds_total", "Total user and system CPU time spent in seconds.");
 
             _virtualMemorySize = metrics.CreateGauge("process_windows_virtual_bytes", "Process virtual memory size");
             _workingSet = metrics.CreateGauge("process_windows_working_set", "Process working set");


### PR DESCRIPTION
updated 
_startTime = metrics.CreateGauge("process_start_time_seconds", "Start time of the process since unix epoch in seconds.");
_cpuTotal = metrics.CreateCounter("process_cpu_seconds_total", "Total user and system CPU time spent in seconds.");
 => added a period in the end of string to address err 500 due to a unit test validation
to fix **https://github.com/prometheus-net/prometheus-net/issues/89**